### PR TITLE
chore: ignore Yarn Berry artifacts (.yarn/, .yarnrc.yml)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,10 @@
 # dependencies
 node_modules
 
+# Yarn Berry artifacts (this project uses Yarn Classic)
+.yarn/
+.yarnrc.yml
+
 # testing
 coverage
 


### PR DESCRIPTION
The repository is configured for Yarn Classic (the committed `yarn.lock` is the classic format). However, contributors whose system `yarn` is Yarn Berry (3.x+) will have `.yarn/` and `.yarnrc.yml` auto-bootstrapped on first install, polluting the working tree with untracked files.

Add both to `.gitignore` with a comment so the intent is clear.

```gitignore
# Yarn Berry artifacts (this project uses Yarn Classic)
.yarn/
.yarnrc.yml
```

If the project ever migrates to Yarn Berry, this block should be revisited.