### PR TITLE
chore(uikit): replace deprecated Prettier --loglevel flag

### DIFF
--- a/packages/plantswap-uikit/package.json
+++ b/packages/plantswap-uikit/package.json
@@ -17,7 +17,7 @@
     "start": "cross-env yarn storybook",
     "build": "rm -rf ./dist && rollup -c && tsc -p tsconfig.json -d --emitDeclarationOnly --declarationDir dist",
     "lint": "eslint 'src/**/*.{js,jsx,ts,tsx}'",
-    "format:check": "prettier --check --loglevel error 'src/**/*.{js,jsx,ts,tsx}'",
+    "format:check": "prettier --check --log-level error 'src/**/*.{js,jsx,ts,tsx}'",
     "format:write": "prettier --write 'src/**/*.{js,jsx,ts,tsx}'",
     "storybook": "storybook dev -p 6006",
     "storybook:build": "storybook build",


### PR DESCRIPTION
## Summary

- `packages/plantswap-uikit/package.json`: rename the `format:check` script flag `--loglevel` to `--log-level` for Prettier 3 compatibility.

## Test plan

- Verified by invoking prettier directly (yarn refused due to `engines.node >=24` on this host):
  - Old `--loglevel error` now prints `[warn] Ignored unknown option --loglevel. Did you mean --log-level?` — the flag is silently ignored under Prettier 3.
  - New `--log-level error` exits 0 with no output — the deprecation warning is gone.

Fixes #88