### PR TITLE
fix(uikit): make useMatchBreakpoints SSR-safe

### DIFF
--- a/packages/plantswap-uikit/src/__tests__/hooks/useMatchBreakpoints.test.tsx
+++ b/packages/plantswap-uikit/src/__tests__/hooks/useMatchBreakpoints.test.tsx
@@ -1,0 +1,46 @@
+import React from "react";
+import { act, renderHook } from "@testing-library/react";
+import { breakpointMap } from "../../theme/base";
+import useMatchBreakpoints from "../../hooks/useMatchBreakpoints";
+
+const expectedKeys = Object.keys(breakpointMap).map(
+  (size) => `is${size.charAt(0).toUpperCase()}${size.slice(1)}`,
+);
+
+describe("useMatchBreakpoints", () => {
+  it("does not access window during initial render", () => {
+    // Simulate a non-browser / SSR environment where `window` is undefined.
+    const originalWindow = globalThis.window;
+    // @ts-expect-error -- intentionally remove window for this test
+    delete (globalThis as { window?: unknown }).window;
+
+    try {
+      const { result } = renderHook(() => useMatchBreakpoints());
+      // Initial render must produce a fully-populated state without touching
+      // `window.matchMedia`. Every breakpoint defaults to `false` until the
+      // effect runs on the client.
+      expect(Object.keys(result.current).sort()).toEqual([...expectedKeys].sort());
+      Object.values(result.current).forEach((value) => {
+        expect(value).toBe(false);
+      });
+    } finally {
+      (globalThis as { window?: unknown }).window = originalWindow;
+    }
+  });
+
+  it("syncs state with matchMedia after mount", () => {
+    // jsdom's default matchMedia returns a MediaQueryList whose `matches` is
+    // false. The hook should keep the same default after mount and only flip
+    // when listeners fire.
+    const { result } = renderHook(() => useMatchBreakpoints());
+
+    expect(Object.keys(result.current).sort()).toEqual([...expectedKeys].sort());
+
+    act(() => {
+      // No-op: ensures any pending effects flushed. State should remain stable
+      // when nothing changes.
+    });
+
+    expect(Object.values(result.current)).toEqual(expect.arrayContaining([false]));
+  });
+});

--- a/packages/plantswap-uikit/src/hooks/useMatchBreakpoints.ts
+++ b/packages/plantswap-uikit/src/hooks/useMatchBreakpoints.ts
@@ -36,22 +36,28 @@ const mediaQueries: MediaQueries = (() => {
 
 const getKey = (size: string) => `is${size.charAt(0).toUpperCase()}${size.slice(1)}`;
 
+const getInitialState = (): State =>
+  Object.keys(mediaQueries).reduce((accum, size) => {
+    const key = getKey(size);
+    return { ...accum, [key]: false };
+  }, {});
+
 const useMatchBreakpoints = (): State => {
-  const [state, setState] = useState<State>(() => {
-    return Object.keys(mediaQueries).reduce((accum, size) => {
-      const key = getKey(size);
-      const mql = window.matchMedia(mediaQueries[size]);
-      return { ...accum, [key]: mql.matches };
-    }, {});
-  });
+  const [state, setState] = useState<State>(getInitialState);
 
   useEffect(() => {
-    // Create listeners for each media query returning a function to unsubscribe
-    const handlers = Object.keys(mediaQueries).map((size) => {
-      const mql = window.matchMedia(mediaQueries[size]);
+    // Sync state with the real viewport after mount, so the hook is safe in
+    // SSR / non-browser environments where `window` is undefined.
+    const mqls = Object.keys(mediaQueries).map((size) => ({
+      key: getKey(size),
+      mql: window.matchMedia(mediaQueries[size]),
+    }));
 
+    setState(mqls.reduce((accum, { key, mql }) => ({ ...accum, [key]: mql.matches }), {}));
+
+    // Create listeners for each media query returning a function to unsubscribe
+    const handlers = mqls.map(({ key, mql }) => {
       const handler = (matchMediaQuery: MediaQueryListEvent) => {
-        const key = getKey(size);
         setState((prevState) => ({
           ...prevState,
           [key]: matchMediaQuery.matches,


### PR DESCRIPTION
## Summary

- Initialize `useMatchBreakpoints` state with safe defaults (every breakpoint `false`) so the hook no longer touches `window.matchMedia` during the initial render.
- Sync state with the actual viewport inside `useEffect`, after mount, so SSR / non-browser environments no longer crash.
- Keep the existing Safari < 14 `addEventListener` fallback intact.
- Add a test under `src/__tests__/hooks/useMatchBreakpoints.test.tsx` covering SSR (no `window`) and post-mount behavior.

## Test plan

- Prettier check on changed files passes.
- Manual: render a component that uses `useMatchBreakpoints` in an SSR build — no `ReferenceError` is thrown.
- The new unit test stubs `globalThis.window` and verifies the hook returns the expected `false`-filled state on initial render.

Fixes #81

Note: `yarn lint` and `yarn test` currently fail in this repo for unrelated reasons (ESLint 10 needs `eslint.config.js`, ts-jest 29 is incompatible with TypeScript 7). Those are tracked separately and are out of scope for this PR.