### PR TITLE
fix(eslint-config): drop removed prettier extends for v10

### DIFF
--- a/packages/eslint-config-plantswap/lib/index.js
+++ b/packages/eslint-config-plantswap/lib/index.js
@@ -23,8 +23,6 @@ module.exports = {
     "airbnb",
     "airbnb/hooks",
     "prettier",
-    "prettier/react",
-    "prettier/@typescript-eslint",
     "plugin:@typescript-eslint/recommended",
   ],
   rules: {


### PR DESCRIPTION
## Summary
- Remove `prettier/react` and `prettier/@typescript-eslint` from `extends` in `@plantswap-libs/eslint-config-plantswap`; those shareable configs were dropped in `eslint-config-prettier` v10 and only `prettier` is needed.
- Verified the remaining extends (`airbnb`, `airbnb/hooks`, `prettier`, `plugin:@typescript-eslint/recommended`) all resolve against the installed `eslint-config-prettier@10.1.8`.
- Confirmed `require.resolve('eslint-config-prettier/react')` and `…/@typescript-eslint` now throw `ERR_PACKAGE_PATH_NOT_EXPORTED`, matching the broken state the issue describes.

## Test plan
- `node -e "require('./packages/eslint-config-plantswap/lib/index.js')"` succeeds and lists only the four v10-valid extends.
- Each extends entry resolves via `require.resolve` against the installed packages.
- `git diff` shows only the two stale lines removed from `packages/eslint-config-plantswap/lib/index.js`.

## Notes / out of scope
- A full `yarn lint` end-to-end run is blocked by a separate, pre-existing issue: ESLint v10 (installed at the root) requires flat config, while the repo still ships `.eslintrc`. Migrating to `eslint.config.js` is issue #77 territory and would touch every consumer — not part of this fix.
- The acceptance criterion "config loads without missing-extend errors" is satisfied at the module-resolution level, which is exactly what the v10 migration broke.

Fixes #79