### PR TITLE
refactor(uikit): simplify modal prop comparison

### DIFF
--- a/packages/plantswap-uikit/src/widgets/Modal/useModal.ts
+++ b/packages/plantswap-uikit/src/widgets/Modal/useModal.ts
@@ -1,13 +1,23 @@
 import React, { useCallback, useContext, useEffect } from "react";
-import get from "lodash/get";
 import { Context } from "./ModalContext";
 import { Handler } from "./types";
+
+const arePropsEqual = (first: object, second: object) => {
+  const firstProps = first as Record<string, unknown>;
+  const secondProps = second as Record<string, unknown>;
+  const firstKeys = Object.keys(firstProps);
+  const secondKeys = Object.keys(secondProps);
+
+  return (
+    firstKeys.length === secondKeys.length && firstKeys.every((key) => Object.is(firstProps[key], secondProps[key]))
+  );
+};
 
 const useModal = (
   modal: React.ReactNode,
   closeOnOverlayClick = true,
   updateOnPropsChange = false,
-  modalId = "defaultNodeId"
+  modalId = "defaultNodeId",
 ): [Handler, Handler] => {
   const { isOpen, nodeId, modalNode, setModalNode, onPresent, onDismiss, setCloseOnOverlayClick } = useContext(Context);
   const onPresentCallback = useCallback(() => {
@@ -20,15 +30,11 @@ const useModal = (
   useEffect(() => {
     // NodeId is needed in case there are 2 useModal hooks on the same page and one has updateOnPropsChange
     if (updateOnPropsChange && isOpen && nodeId === modalId) {
-      const modalProps = get(modal, "props");
-      const oldModalProps = get(modalNode, "props");
-      // Note: I tried to use lodash isEqual to compare props but it is giving false-negatives too easily
-      // For example ConfirmSwapModal in exchange has ~500 lines prop object that stringifies to same string
-      // and online diff checker says both objects are identical but lodash isEqual thinks they are different
-      // Do not try to replace JSON.stringify with isEqual, high risk of infinite rerenders
-      // TODO: Find a good way to handle modal updates, this whole flow is just backwards-compatible workaround,
-      // would be great to simplify the logic here
-      if (modalProps && oldModalProps && JSON.stringify(modalProps) !== JSON.stringify(oldModalProps)) {
+      const modalProps = React.isValidElement(modal) ? modal.props : undefined;
+      const oldModalProps = React.isValidElement(modalNode) ? modalNode.props : undefined;
+      // Props are compared shallowly so stable values update the modal without serializing React elements.
+      // Callers passing new object or array props should memoize them when using updateOnPropsChange.
+      if (modalProps && oldModalProps && !arePropsEqual(modalProps, oldModalProps)) {
         setModalNode(modal);
       }
     }


### PR DESCRIPTION
## Summary
- replace JSON serialization in `useModal` prop updates with a shallow comparison
- preserve the existing `updateOnPropsChange` compatibility API
- document the memoization requirement for object and array props

## Test plan
- `yarn tsc -p packages/plantswap-uikit/tsconfig.json --noEmit`
- `yarn prettier --check packages/plantswap-uikit/src/widgets/Modal/useModal.ts`
- UIkit lint and Jest remain blocked by the repository's ESLint 10 flat-config and TypeScript 7/ts-jest setup

Fixes #87