### PR TITLE
fix: migrate Husky v9 hooks so pre-commit and commit-msg actually run

### DIFF
--- a/.husky/commit-msg
+++ b/.husky/commit-msg
@@ -1,0 +1,1 @@
+yarn commitlint --edit "$1"

--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -1,0 +1,8 @@
+FILES=$(git diff --cached --name-only --diff-filter=ACMR | grep -E '\.(js|jsx|ts|tsx)$' || true)
+
+if [ -z "$FILES" ]; then
+  exit 0
+fi
+
+printf '%s\n' "$FILES" | tr '\n' '\0' | xargs -0 yarn prettier --write
+printf '%s\n' "$FILES" | tr '\n' '\0' | xargs -0 git add

--- a/README.md
+++ b/README.md
@@ -25,3 +25,12 @@ yarn
 ```
 
 Then, refer to the readme of each project.
+
+## Git hooks
+
+Git hooks are managed with [Husky](https://typicode.github.io/husky/). Running `yarn` at the root installs them automatically via the `prepare` script:
+
+- `pre-commit` formats staged `.js`/`.jsx`/`.ts`/`.tsx` files with Prettier and re-stages them.
+- `commit-msg` runs [commitlint](https://commitlint.js.org/), which enforces [Conventional Commits](https://www.conventionalcommits.org/) with a sentence-case subject (e.g. `fix: Correct the button padding`).
+
+To bypass the hooks for a single commit, use `git commit --no-verify`.

--- a/package.json
+++ b/package.json
@@ -22,18 +22,13 @@
   },
   "homepage": "https://github.com/plantswapfinance/plantswapfinance-toolkit#readme",
   "scripts": {
+    "prepare": "husky",
     "build": "lerna run build",
     "test": "lerna run test",
     "lint": "lerna run lint",
     "format:check": "lerna run format:check",
     "storybook:build": "lerna run storybook:build",
     "release": "yarn build && yarn lerna publish"
-  },
-  "husky": {
-    "hooks": {
-      "pre-commit": "yarn format:check",
-      "commit-msg": "commitlint -E HUSKY_GIT_PARAMS"
-    }
   },
   "devDependencies": {
     "@babel/core": "^8.0.0",


### PR DESCRIPTION
## Summary

- Husky was bumped to v9 (`9.1.7`), but the repo still used the legacy `husky.hooks` block in `package.json` and had no `.husky/` directory — so **`pre-commit` and `commit-msg` never ran**.
- Adds `.husky/pre-commit` and `.husky/commit-msg` in the v9 format (mode `755`), plus a `"prepare": "husky"` script so hooks install automatically on `yarn`.
- Removes the obsolete `husky.hooks` config from `package.json` and documents hook setup (and `--no-verify`) in the root README.

### Note on `pre-commit`

The old hook ran `yarn format:check`, but that currently **fails on 166 pre-existing files** — wiring it up as-is would block every commit in the repo. Instead `pre-commit` runs Prettier on **staged** `.js/.jsx/.ts/.tsx` files only and re-stages them, so you're never blocked by files you didn't touch.

This is done inline with the already-present `prettier` dependency rather than adding `lint-staged`, deliberately: the committed `yarn.lock` is **Yarn Berry v6** format, while `.yarnrc.yml` is gitignored and no `packageManager` field is set — so a fresh clone gets Yarn Classic, which rewrites the entire lockfile. Adding any dependency here produces a ~26k-line lockfile churn that no CI validates. **No new dependencies and `yarn.lock` is untouched by this PR.** That Yarn inconsistency is pre-existing and worth its own issue.

## Test plan

Husky runs hooks via `sh -e`, so each case was verified under `sh -e` (not just a bare invocation, which masks `set -e` failures):

| Case | Expected | Result |
| --- | --- | --- |
| Staged `.ts` file, badly formatted | formatted + re-staged, exit 0 | ✅ |
| Staged filename containing a space | handled correctly, exit 0 | ✅ |
| No `.js/.ts` files staged | exit 0, commit proceeds | ✅ |
| Staged file with unparseable syntax | non-zero, commit blocked | ✅ |

The no-match case caught a real bug mid-review: `grep` exits 1 when nothing matches, which under `sh -e` aborted the hook and would have blocked every commit that didn't touch a JS/TS file. Fixed with `|| true`.

Both hooks were also confirmed firing on a real `git commit`:

- The commit on this branch shows `commitlint --edit` running and passing via `commit-msg`.
- `git commit --allow-empty -m "nonsense message"` was **rejected** (`husky - commit-msg script failed (code 1)`) and `HEAD` stayed unchanged.

## Acceptance criteria

- [x] `.husky/pre-commit` formats staged files with Prettier (the issue's `or lint-staged` option, minus the dependency)
- [x] `.husky/commit-msg` runs commitlint
- [x] Hooks fire on a local commit

Fixes #76