### PR TITLE
refactor(uikit): replace function-component defaultProps for React 19

### DIFF
--- a/packages/plantswap-uikit/src/components/Button/Button.tsx
+++ b/packages/plantswap-uikit/src/components/Button/Button.tsx
@@ -4,7 +4,18 @@ import StyledButton from "./StyledButton";
 import { ButtonProps, scales, variants } from "./types";
 
 const Button = <E extends ElementType = "button">(props: ButtonProps<E>): React.JSX.Element => {
-  const { startIcon, endIcon, external, className, isLoading, disabled, children, ...rest } = props;
+  const {
+    startIcon,
+    endIcon,
+    external = false,
+    className,
+    isLoading = false,
+    disabled = false,
+    variant = variants.PRIMARY,
+    scale = scales.MD,
+    children,
+    ...rest
+  } = props;
   const internalProps = external ? getExternalLinkProps() : {};
   const isDisabled = isLoading || disabled;
   const classNames = className ? [className] : [];
@@ -22,6 +33,8 @@ const Button = <E extends ElementType = "button">(props: ButtonProps<E>): React.
       $isLoading={isLoading}
       className={classNames.join(" ")}
       disabled={isDisabled}
+      variant={variant}
+      scale={scale}
       {...internalProps}
       {...rest}
     >
@@ -38,14 +51,6 @@ const Button = <E extends ElementType = "button">(props: ButtonProps<E>): React.
       </>
     </StyledButton>
   );
-};
-
-Button.defaultProps = {
-  isLoading: false,
-  external: false,
-  variant: variants.PRIMARY,
-  scale: scales.MD,
-  disabled: false,
 };
 
 export default Button;

--- a/packages/plantswap-uikit/src/components/Button/ExpandableButton.tsx
+++ b/packages/plantswap-uikit/src/components/Button/ExpandableButton.tsx
@@ -9,7 +9,7 @@ interface Props {
   children?: React.ReactNode;
 }
 
-export const ExpandableButton: React.FC<Props> = ({ onClick, expanded, children }) => {
+export const ExpandableButton: React.FC<Props> = ({ onClick, expanded = false, children }) => {
   return (
     <IconButton aria-label="Hide or show expandable content" onClick={onClick}>
       {children}
@@ -18,11 +18,7 @@ export const ExpandableButton: React.FC<Props> = ({ onClick, expanded, children 
   );
 };
 
-(ExpandableButton as any).defaultProps = {
-  expanded: false,
-};
-
-export const ExpandableLabel: React.FC<Props> = ({ onClick, expanded, children }) => {
+export const ExpandableLabel: React.FC<Props> = ({ onClick, expanded = false, children }) => {
   return (
     <Button
       variant="text"
@@ -33,8 +29,4 @@ export const ExpandableLabel: React.FC<Props> = ({ onClick, expanded, children }
       {children}
     </Button>
   );
-};
-
-(ExpandableLabel as any).defaultProps = {
-  expanded: false,
 };

--- a/packages/plantswap-uikit/src/components/Card/CardBody.tsx
+++ b/packages/plantswap-uikit/src/components/Card/CardBody.tsx
@@ -4,12 +4,8 @@ import filterDomProps from "../../util/filterDomProps";
 
 export type CardBodyProps = SpaceProps;
 
-const CardBody = styled.div.withConfig(filterDomProps)<CardBodyProps>`
+const CardBody = styled.div.withConfig(filterDomProps).attrs<CardBodyProps>(({ p = "24px" }) => ({ p }))<CardBodyProps>`
   ${space}
 `;
-
-(CardBody as any).defaultProps = {
-  p: "24px",
-};
 
 export default CardBody;

--- a/packages/plantswap-uikit/src/components/Card/CardFooter.tsx
+++ b/packages/plantswap-uikit/src/components/Card/CardFooter.tsx
@@ -4,13 +4,11 @@ import filterDomProps from "../../util/filterDomProps";
 
 export type CardFooterProps = SpaceProps;
 
-const CardFooter = styled.div.withConfig(filterDomProps)<CardFooterProps>`
+const CardFooter = styled.div
+  .withConfig(filterDomProps)
+  .attrs<CardFooterProps>(({ p = "24px" }) => ({ p }))<CardFooterProps>`
   border-top: 1px solid ${({ theme }) => theme.colors.cardBorder};
   ${space}
 `;
-
-(CardFooter as any).defaultProps = {
-  p: "24px",
-};
 
 export default CardFooter;

--- a/packages/plantswap-uikit/src/components/Card/CardHeader.tsx
+++ b/packages/plantswap-uikit/src/components/Card/CardHeader.tsx
@@ -7,13 +7,11 @@ export interface CardHeaderProps extends SpaceProps {
   variant?: keyof CardTheme["cardHeaderBackground"];
 }
 
-const CardHeader = styled.div.withConfig(filterDomProps)<CardHeaderProps>`
+const CardHeader = styled.div
+  .withConfig(filterDomProps)
+  .attrs<CardHeaderProps>(({ p = "24px" }) => ({ p }))<CardHeaderProps>`
   background: ${({ theme, variant = "default" }) => theme.card.cardHeaderBackground[variant]};
   ${space}
 `;
-
-(CardHeader as any).defaultProps = {
-  p: "24px",
-};
 
 export default CardHeader;

--- a/packages/plantswap-uikit/src/components/Card/CardRibbon.tsx
+++ b/packages/plantswap-uikit/src/components/Card/CardRibbon.tsx
@@ -53,16 +53,12 @@ const StyledCardRibbon = styled.div.withConfig(filterDomProps)<Partial<StyledCar
   }
 `;
 
-const CardRibbon: React.FC<CardRibbonProps> = ({ variantColor, text, ribbonPosition, ...props }) => {
+const CardRibbon: React.FC<CardRibbonProps> = ({ variantColor, text, ribbonPosition = "right", ...props }) => {
   return (
     <StyledCardRibbon variantColor={variantColor} ribbonPosition={ribbonPosition} {...props}>
       <div title={text}>{text}</div>
     </StyledCardRibbon>
   );
-};
-
-(CardRibbon as any).defaultProps = {
-  ribbonPosition: "right",
 };
 
 export default CardRibbon;

--- a/packages/plantswap-uikit/src/components/Card/StyledCard.tsx
+++ b/packages/plantswap-uikit/src/components/Card/StyledCard.tsx
@@ -26,7 +26,14 @@ const getBoxShadow = ({ isActive, isSuccess, isWarning, theme }: StyledCardProps
   return theme.card.boxShadow;
 };
 
-const StyledCard = styled.div.withConfig(filterDomProps)<StyledCardProps>`
+const StyledCard = styled.div
+  .withConfig(filterDomProps)
+  .attrs<StyledCardProps>(({ isActive = false, isSuccess = false, isWarning = false, isDisabled = false }) => ({
+    isActive,
+    isSuccess,
+    isWarning,
+    isDisabled,
+  }))<StyledCardProps>`
   background-color: ${({ theme }) => theme.card.background};
   border: ${({ theme }) => theme.card.boxShadow};
   border-radius: ${({ theme }) => theme.radii.card};
@@ -37,12 +44,5 @@ const StyledCard = styled.div.withConfig(filterDomProps)<StyledCardProps>`
 
   ${space}
 `;
-
-(StyledCard as any).defaultProps = {
-  isActive: false,
-  isSuccess: false,
-  isWarning: false,
-  isDisabled: false,
-};
 
 export default StyledCard;

--- a/packages/plantswap-uikit/src/components/Checkbox/Checkbox.tsx
+++ b/packages/plantswap-uikit/src/components/Checkbox/Checkbox.tsx
@@ -12,7 +12,9 @@ const getScale = ({ scale }: CheckboxProps) => {
   }
 };
 
-const Checkbox = styled.input.withConfig(filterDomProps).attrs({ type: "checkbox" })<CheckboxProps>`
+const Checkbox = styled.input
+  .withConfig(filterDomProps)
+  .attrs<CheckboxProps>(({ scale = scales.MD }) => ({ type: "checkbox", scale }))<CheckboxProps>`
   appearance: none;
   overflow: hidden;
   cursor: pointer;
@@ -64,9 +66,5 @@ const Checkbox = styled.input.withConfig(filterDomProps).attrs({ type: "checkbox
     opacity: 0.6;
   }
 `;
-
-(Checkbox as any).defaultProps = {
-  scale: scales.MD,
-};
 
 export default Checkbox;

--- a/packages/plantswap-uikit/src/components/Dropdown/Dropdown.tsx
+++ b/packages/plantswap-uikit/src/components/Dropdown/Dropdown.tsx
@@ -49,8 +49,5 @@ const Dropdown: React.FC<DropdownProps> = ({ target, position = "bottom", childr
     </Container>
   );
 };
-(Dropdown as any).defaultProps = {
-  position: "bottom",
-};
 
 export default Dropdown;

--- a/packages/plantswap-uikit/src/components/Heading/Heading.tsx
+++ b/packages/plantswap-uikit/src/components/Heading/Heading.tsx
@@ -21,7 +21,7 @@ const style = {
   },
 };
 
-const Heading = styled(Text).attrs({ bold: true })<HeadingProps>`
+const Heading = styled(Text).attrs<HeadingProps>(({ as = tags.H2 }) => ({ bold: true, as }))<HeadingProps>`
   font-size: ${({ scale }: HeadingProps) => style[scale || scales.MD].fontSize};
   font-weight: 600;
   line-height: 1.1;
@@ -30,9 +30,5 @@ const Heading = styled(Text).attrs({ bold: true })<HeadingProps>`
     font-size: ${({ scale }: HeadingProps) => style[scale || scales.MD].fontSizeLg};
   }
 `;
-
-(Heading as any).defaultProps = {
-  as: tags.H2,
-};
 
 export default Heading;

--- a/packages/plantswap-uikit/src/components/Heading/types.ts
+++ b/packages/plantswap-uikit/src/components/Heading/types.ts
@@ -5,7 +5,7 @@ export const tags = {
   H4: "h4",
   H5: "h5",
   H6: "h6",
-};
+} as const;
 
 export const scales = {
   MD: "md",
@@ -14,8 +14,8 @@ export const scales = {
   XXL: "xxl",
 } as const;
 
-export type Tags = typeof tags[keyof typeof tags];
-export type Scales = typeof scales[keyof typeof scales];
+export type Tags = (typeof tags)[keyof typeof tags];
+export type Scales = (typeof scales)[keyof typeof scales];
 
 export interface HeadingProps {
   as?: Tags;

--- a/packages/plantswap-uikit/src/components/Input/Input.tsx
+++ b/packages/plantswap-uikit/src/components/Input/Input.tsx
@@ -33,7 +33,13 @@ const getHeight = ({ scale = scales.MD }: StyledInputProps) => {
   }
 };
 
-const Input = styled.input.withConfig(filterDomProps)<InputProps>`
+const Input = styled.input
+  .withConfig(filterDomProps)
+  .attrs<InputProps>(({ scale = scales.MD, isSuccess = false, isWarning = false }) => ({
+    scale,
+    isSuccess,
+    isWarning,
+  }))<InputProps>`
   background-color: ${({ theme }) => theme.colors.input};
   border: 0;
   border-radius: 16px;
@@ -62,11 +68,5 @@ const Input = styled.input.withConfig(filterDomProps)<InputProps>`
     box-shadow: ${({ theme }) => theme.shadows.focus};
   }
 `;
-
-(Input as any).defaultProps = {
-  scale: scales.MD,
-  isSuccess: false,
-  isWarning: false,
-};
 
 export default Input;

--- a/packages/plantswap-uikit/src/components/Link/Link.tsx
+++ b/packages/plantswap-uikit/src/components/Link/Link.tsx
@@ -13,13 +13,9 @@ const StyledLink = styled(Text)<LinkProps>`
   }
 `;
 
-const Link: React.FC<LinkProps> = ({ external, ...props }) => {
+const Link: React.FC<LinkProps> = ({ external, color = "primary", ...props }) => {
   const internalProps = external ? getExternalLinkProps() : {};
-  return <StyledLink as="a" bold {...internalProps} {...props} />;
-};
-
-(Link as any).defaultProps = {
-  color: "primary",
+  return <StyledLink as="a" bold color={color} {...internalProps} {...props} />;
 };
 
 export default Link;

--- a/packages/plantswap-uikit/src/components/Overlay/Overlay.tsx
+++ b/packages/plantswap-uikit/src/components/Overlay/Overlay.tsx
@@ -2,7 +2,11 @@ import styled from "styled-components";
 import { OverlayProps } from "./types";
 import filterDomProps from "../../util/filterDomProps";
 
-const Overlay = styled.div.withConfig(filterDomProps).attrs({ role: "presentation" })<OverlayProps>`
+const Overlay = styled.div.withConfig(filterDomProps).attrs<OverlayProps>(({ show = false, zIndex = 10 }) => ({
+  role: "presentation",
+  show,
+  zIndex,
+}))<OverlayProps>`
   position: fixed;
   top: 0px;
   left: 0px;
@@ -14,10 +18,5 @@ const Overlay = styled.div.withConfig(filterDomProps).attrs({ role: "presentatio
   z-index: ${({ zIndex }) => zIndex};
   pointer-events: ${({ show }) => (show ? "initial" : "none")};
 `;
-
-(Overlay as any).defaultProps = {
-  show: false,
-  zIndex: 10,
-};
 
 export default Overlay;

--- a/packages/plantswap-uikit/src/components/PlantToggle/PlantToggle.tsx
+++ b/packages/plantswap-uikit/src/components/PlantToggle/PlantToggle.tsx
@@ -13,8 +13,4 @@ const PlantToggle: React.FC<PlantToggleProps> = ({ checked, scale = scales.MD, .
   </PlantStack>
 );
 
-(PlantToggle as any).defaultProps = {
-  scale: scales.MD,
-};
-
 export default PlantToggle;

--- a/packages/plantswap-uikit/src/components/Progress/StyledProgress.tsx
+++ b/packages/plantswap-uikit/src/components/Progress/StyledProgress.tsx
@@ -8,7 +8,9 @@ interface BarProps {
   primary?: boolean;
 }
 
-export const Bar = styled.div.withConfig(filterDomProps)<BarProps>`
+export const Bar = styled.div.withConfig(filterDomProps).attrs<BarProps>(({ primary = false }) => ({
+  primary,
+}))<BarProps>`
   position: absolute;
   top: 0;
   left: 0;
@@ -16,10 +18,6 @@ export const Bar = styled.div.withConfig(filterDomProps)<BarProps>`
   height: 100%;
   transition: width 200ms ease;
 `;
-
-(Bar as any).defaultProps = {
-  primary: false,
-};
 
 interface StyledProgressProps {
   variant: ProgressProps["variant"];

--- a/packages/plantswap-uikit/src/components/Radio/Radio.tsx
+++ b/packages/plantswap-uikit/src/components/Radio/Radio.tsx
@@ -23,7 +23,9 @@ const getCheckedScale = ({ scale }: RadioProps) => {
   }
 };
 
-const Radio = styled.input.withConfig(filterDomProps).attrs({ type: "radio" })<RadioProps>`
+const Radio = styled.input
+  .withConfig(filterDomProps)
+  .attrs<RadioProps>(({ scale = scales.MD, m = 0 }) => ({ type: "radio", scale, m }))<RadioProps>`
   appearance: none;
   overflow: hidden;
   cursor: pointer;
@@ -70,10 +72,5 @@ const Radio = styled.input.withConfig(filterDomProps).attrs({ type: "radio" })<R
   }
   ${space}
 `;
-
-(Radio as any).defaultProps = {
-  scale: scales.MD,
-  m: 0,
-};
 
 export default Radio;

--- a/packages/plantswap-uikit/src/components/Svg/Svg.tsx
+++ b/packages/plantswap-uikit/src/components/Svg/Svg.tsx
@@ -17,19 +17,19 @@ const spinStyle = css`
   animation: ${rotate} 2s linear infinite;
 `;
 
-const Svg = styled.svg.withConfig(filterDomProps)<SvgProps>`
+const Svg = styled.svg
+  .withConfig(filterDomProps)
+  .attrs<SvgProps>(({ color = "text", width = "20px", xmlns = "http://www.w3.org/2000/svg", spin = false }) => ({
+    color,
+    width,
+    xmlns,
+    spin,
+  }))<SvgProps>`
   align-self: center; // Safari fix
   fill: ${({ theme, color }) => getThemeValue(`colors.${color}`, color)(theme)};
   flex-shrink: 0;
   ${({ spin }) => spin && spinStyle}
   ${space}
 `;
-
-(Svg as any).defaultProps = {
-  color: "text",
-  width: "20px",
-  xmlns: "http://www.w3.org/2000/svg",
-  spin: false,
-};
 
 export default Svg;

--- a/packages/plantswap-uikit/src/components/TabMenu/Tab.tsx
+++ b/packages/plantswap-uikit/src/components/TabMenu/Tab.tsx
@@ -7,7 +7,7 @@ const getBorderRadius = ({ scale }: TabProps) => (scale === "md" ? "16px 16px 0 
 
 const getPadding = ({ scale }: TabProps) => (scale === "md" ? "8px" : "16px");
 
-const Tab = styled.button.withConfig(filterDomProps)<TabProps>`
+const Tab = styled.button.withConfig(filterDomProps).attrs<TabProps>(({ scale = "md" }) => ({ scale }))<TabProps>`
   display: inline-flex;
   justify-content: center;
   cursor: pointer;
@@ -25,9 +25,5 @@ const Tab = styled.button.withConfig(filterDomProps)<TabProps>`
 
   ${color}
 `;
-
-(Tab as any).defaultProps = {
-  scale: "md",
-};
 
 export default Tab;

--- a/packages/plantswap-uikit/src/components/Text/Text.tsx
+++ b/packages/plantswap-uikit/src/components/Text/Text.tsx
@@ -16,7 +16,9 @@ const getFontSize = ({ fontSize, small }: TextProps) => {
   return small ? "14px" : fontSize || "16px";
 };
 
-const Text = styled.div.withConfig(filterDomProps)<TextProps>`
+const Text = styled.div
+  .withConfig(filterDomProps)
+  .attrs<TextProps>(({ color = "text", small = false, ellipsis = false }) => ({ color, small, ellipsis }))<TextProps>`
   color: ${getColor};
   font-size: ${getFontSize};
   font-weight: ${({ bold }) => (bold ? 600 : 400)};
@@ -32,11 +34,5 @@ const Text = styled.div.withConfig(filterDomProps)<TextProps>`
   ${typography}
   ${layout}
 `;
-
-(Text as any).defaultProps = {
-  color: "text",
-  small: false,
-  ellipsis: false,
-};
 
 export default Text;


### PR DESCRIPTION
## Summary

- React 19 no longer applies `defaultProps` to function components, so all 19 components that declared defaults that way were **silently losing them at runtime**. This turned out to be more than a deprecation cleanup — it was an active bug.
- **Styled components** now resolve defaults with a *function-form* `.attrs()`, e.g. `.attrs<SvgProps>(({ color = "text" }) => ({ color }))`. The callback form is required: a static `.attrs({ color: "text" })` object *overrides* caller-supplied props, whereas the callback reproduces `defaultProps` semantics exactly (caller wins; the default only fills in `undefined`). Verified empirically before applying.
- **Plain function components** (`Button`, `Link`, `CardRibbon`, `ExpandableButton`/`Label`, `Dropdown`, `PlantToggle`) take defaults in parameter destructuring. `Button` and `Link` now forward the previously-defaulted `variant`/`scale`/`color` explicitly, since those no longer arrive via `defaultProps`.
- `tags` in `Heading/types.ts` is `as const` so `as` narrows to a valid styled-components target instead of `string` (without this, `Heading` stopped accepting `children`).

No `defaultProps` remain in `packages/plantswap-uikit/src`.

## Test plan

- `tsc -p tsconfig.json --noEmit`: **0 errors**, matching the clean baseline on `main`.
- `rollup -c` + declaration emit: builds `index.cjs.js` / `index.esm.js` / `index.d.ts`; inspected the emitted bundle to confirm the `.attrs` callbacks transpile correctly.
- Prettier: changed files are clean.
- Unit tests: **`yarn test` cannot run on `main` at all** — `ts-jest` doesn't support the installed TypeScript 7, so all 32 suites error out before executing (see note below). To verify behaviour I ran the suite through a temporary transformer using the repo's own Babel 8 (the same version the Rollup build uses), then compared `main` against this branch on the identical harness:

  | | suites | tests | snapshots |
  |---|---|---|---|
  | `main` | 25 failed / 7 passed | 31 failed / 11 passed | 29 failed / 7 passed |
  | this branch | 14 failed / 18 passed | 19 failed / 23 passed | 17 failed / 19 passed |

  **11 suites went from failing to passing, with zero regressions** (the suite-level diff contains only removals): `svg`, `text`, `heading`, `card`, `checkbox`, `radio`, `input`, `overlay`, `link`, `tabmenu`, `balanceinput`. Those suites' committed snapshots encode the intended defaults (e.g. `color="text"` / `width="20px"` on `Svg`), which React 19 had stopped applying — so the existing snapshots are themselves the assertion that this fix is correct.

  The 14 still-failing suites all failed identically on `main` for one unrelated reason: CSS whitespace serialization drift, e.g. `rgba(14, 14, 44, 0.4)` → `rgba(14,14,44,0.4)`. Untouched here.

## Out of scope (pre-existing, found while verifying)

Not fixed in this PR, but worth separate issues:

1. `ts-jest` is incompatible with TypeScript 7 — `yarn test` fails on every suite on `main`.
2. `jest-config` pulls a nested `@babel/core` **7.29.7** while the build uses **8.0.1**; the older one can't parse type arguments on member calls, so it fails on syntax the shipped build handles fine.
3. Snapshot drift from styled-components CSS whitespace serialization (the 14 suites above).
4. `yarn lint` is broken repo-wide — ESLint 10 requires flat config, but the repo has `.eslintrc`.
5. `format:check` reports 170 pre-existing files, and `dist/index.cjs.js` has a styled-components CJS interop problem.

Items 1 and 4 mean CI added for #77 would be red on a known-good commit until they're addressed.

Fixes #84