### PR TITLE
fix(uikit): Broaden peerDependency ranges to React 18 and react-router 6

### DIFF
--- a/packages/plantswap-uikit/README.md
+++ b/packages/plantswap-uikit/README.md
@@ -10,6 +10,27 @@ PlantSwap UIkit is a set of React components and hooks used to build pages on Pl
 
 > **Note:** the package was previously published as `@plantswap-libs/uikit`. That name is frozen at `0.0.9` and no longer receives updates — use `@plantswap/uikit` instead.
 
+## Peer dependencies
+
+The UIkit does not bundle React, the router, or styled-components — your app
+provides them. Supported majors:
+
+| Peer                  | Supported ranges                    |
+| --------------------- | ----------------------------------- |
+| `react` / `react-dom` | `^17.0.2 \|\| ^18.0.0 \|\| ^19.0.0` |
+| `react-router-dom`    | `^5.2.0 \|\| ^6.0.0 \|\| ^7.0.0`    |
+| `styled-components`   | `^5.2.3 \|\| ^6.0.0`                |
+
+The UIkit only touches the router surface that is stable across all three
+majors — `Link`, `NavLink`, `useLocation`, and the router providers. Active
+menu state is derived from `useLocation()` rather than the `activeClassName`
+prop that react-router v5 offered and v6 removed, so `Menu` navigation
+behaves the same on every supported major.
+
+One combination is ruled out by the router itself, not by us:
+`react-router-dom@7` declares `react >=18`, so pair it with React 18 or 19. If
+you are still on React 17, stay on `react-router-dom` v5 or v6.
+
 ## Setup
 
 ### Theme

--- a/packages/plantswap-uikit/package.json
+++ b/packages/plantswap-uikit/package.json
@@ -42,9 +42,9 @@
     "styled-components": "^6.0.0"
   },
   "peerDependencies": {
-    "react": "^17.0.2 || ^19.0.0",
-    "react-dom": "^17.0.2 || ^19.0.0",
-    "react-router-dom": "^5.2.0 || ^7.0.0",
+    "react": "^17.0.2 || ^18.0.0 || ^19.0.0",
+    "react-dom": "^17.0.2 || ^18.0.0 || ^19.0.0",
+    "react-router-dom": "^5.2.0 || ^6.0.0 || ^7.0.0",
     "styled-components": "^5.2.3 || ^6.0.0"
   },
   "dependencies": {

--- a/yarn.lock
+++ b/yarn.lock
@@ -3864,9 +3864,9 @@ __metadata:
     styled-components: "npm:^6.0.0"
     styled-system: "npm:^5.1.5"
   peerDependencies:
-    react: ^17.0.2 || ^19.0.0
-    react-dom: ^17.0.2 || ^19.0.0
-    react-router-dom: ^5.2.0 || ^7.0.0
+    react: ^17.0.2 || ^18.0.0 || ^19.0.0
+    react-dom: ^17.0.2 || ^18.0.0 || ^19.0.0
+    react-router-dom: ^5.2.0 || ^6.0.0 || ^7.0.0
     styled-components: ^5.2.3 || ^6.0.0
   languageName: unknown
   linkType: soft


### PR DESCRIPTION
## Summary

- Add the skipped middle majors to `@plantswap/uikit` peers: `react`/`react-dom` become `^17.0.2 || ^18.0.0 || ^19.0.0` and `react-router-dom` becomes `^5.2.0 || ^6.0.0 || ^7.0.0`.
- No source changes were needed. The UIkit only imports router API that is stable across v5/v6/v7 — `Link`, `NavLink`, `useLocation`, `BrowserRouter`, `MemoryRouter`. Active menu state is derived from `useLocation()` in `PanelBody`, not the `activeClassName` prop that v5 offered and v6 removed, so `Menu` is already major-agnostic.
- Document the supported matrix in the package README, including the one combination the router itself rules out: `react-router-dom@7` declares `react >=18`, so React 17 consumers must stay on router v5 or v6.

## Test plan

Verified compatibility empirically rather than by inspection alone.

**1. Export surface exists in every supported major** — the 5 symbols the UIkit imports, checked against real installs:

| Package | Version | Missing exports | Own peers |
| --- | --- | --- | --- |
| `react-router-dom` | 5.3.4 | none | `react >=15` |
| `react-router-dom` | 6.30.4 | none | `react >=16.8` |
| `react-router-dom` | 7.18.2 | none | `react >=18` |

**2. Rendered the actual `MenuLink` source** (`renderToStaticMarkup`, one React copy) against each router major:

| Router | Internal link markup |
| --- | --- |
| 5.3.4 | `<a aria-current="page" class="active" href="/farms">Farms</a>` |
| 6.30.4 | `<a aria-current="page" class="active" href="/farms">Farms</a>` |
| 7.18.2 | `<a aria-current="page" class="active" href="/farms" data-discover="true">Farms</a>` |

Active styling (`class="active"` + `aria-current="page"`) is applied on **all three** majors, so `Menu` active state is preserved. External links render identically everywhere (`<a target="_blank" rel="noopener noreferrer" href="...">`), and `useLocation().pathname` returns `/farms` on all three. The only delta is v7's cosmetic `data-discover` attribute.

**3. React × router combinations rendered successfully:** React 17+v5, React 17+v6, React 18+v5/v6/v7, React 19+v7.

**4. Semver ranges assert what the README claims** — `16.14.0`, `20.0.0`, `react-router-dom@4.4.0` and `@8.0.0` are correctly rejected; every documented version is accepted.

**5.** `prettier --check` passes on both changed files.

### Note on the existing toolchain

`yarn test` and `yarn lint` **fail on `main`** independently of this PR (verified by stashing these changes and re-running on a clean tree):

- `ts-jest@29` refuses `typescript@7.0.2` → all 32 suites fail to transform, `0 tests total`.
- `eslint@10` can't read the legacy `.eslintrc` → "couldn't find an eslint.config.js".

Both are pre-existing and out of scope here, which is why the verification above is external rather than a new jest test — a test added in this PR could not be executed. Worth folding into #77 (CI), which would have caught these.

Fixes #80