### PR TITLE
fix(uikit): wrap stories in a global ThemeProvider

### DIFF
--- a/packages/plantswap-uikit/.storybook/preview.tsx
+++ b/packages/plantswap-uikit/.storybook/preview.tsx
@@ -1,6 +1,5 @@
 import React from "react";
 import { ThemeProvider } from "styled-components";
-/* eslint-disable import/no-unresolved */
 import type { Preview } from "@storybook/react";
 import { light } from "../src/theme";
 

--- a/packages/plantswap-uikit/.storybook/preview.tsx
+++ b/packages/plantswap-uikit/.storybook/preview.tsx
@@ -1,0 +1,17 @@
+import React from "react";
+import { ThemeProvider } from "styled-components";
+/* eslint-disable import/no-unresolved */
+import type { Preview } from "@storybook/react";
+import { light } from "../src/theme";
+
+const preview: Preview = {
+  decorators: [
+    (Story) => (
+      <ThemeProvider theme={light}>
+        <Story />
+      </ThemeProvider>
+    ),
+  ],
+};
+
+export default preview;

--- a/packages/plantswap-uikit/src/components/Svg/index.stories.tsx
+++ b/packages/plantswap-uikit/src/components/Svg/index.stories.tsx
@@ -25,13 +25,16 @@ export const Default: React.FC = () => (
 );
 
 const modules = import.meta.glob("./Icons/*.tsx", { eager: true });
-const components = Object.entries(modules).reduce<Record<string, React.ComponentType<unknown>>>((accum, [path, mod]) => {
-  const file = path.replace(/^\.\/Icons\//, "").replace(".tsx", "");
-  return {
-    ...accum,
-    [file]: (mod as { default: React.ComponentType<unknown> }).default,
-  };
-}, {});
+const components = Object.entries(modules).reduce<Record<string, React.ComponentType<unknown>>>(
+  (accum, [path, mod]) => {
+    const file = path.replace(/^\.\/Icons\//, "").replace(".tsx", "");
+    return {
+      ...accum,
+      [file]: (mod as { default: React.ComponentType<unknown> }).default,
+    };
+  },
+  {},
+);
 
 export const Icons: React.FC = () => (
   <Flex justifyContent="start" alignItems="center" flexWrap="wrap">

--- a/packages/plantswap-uikit/src/components/Svg/index.stories.tsx
+++ b/packages/plantswap-uikit/src/components/Svg/index.stories.tsx
@@ -24,19 +24,19 @@ export const Default: React.FC = () => (
   </div>
 );
 
-const context = require.context("./Icons", true, /.tsx$/);
-const components = context.keys().reduce((accum, path) => {
-  const file = path.substring(2).replace(".tsx", "");
+const modules = import.meta.glob("./Icons/*.tsx", { eager: true });
+const components = Object.entries(modules).reduce<Record<string, React.ComponentType<unknown>>>((accum, [path, mod]) => {
+  const file = path.replace(/^\.\/Icons\//, "").replace(".tsx", "");
   return {
     ...accum,
-    [file]: context(path),
+    [file]: (mod as { default: React.ComponentType<unknown> }).default,
   };
 }, {});
 
 export const Icons: React.FC = () => (
   <Flex justifyContent="start" alignItems="center" flexWrap="wrap">
     {Object.keys(components).map((file) => {
-      const Icon = components[file].default;
+      const Icon = components[file];
       return (
         <Flex
           key={file}


### PR DESCRIPTION
Fixes two storybook crashes on the deploy preview:

1. `TypeError: Cannot read properties of undefined (reading 'background')` — Alert story
2. `TypeError: e.context is not a function` — SVG Icons story

The v10 storybook migration (commit 0d8a46a) dropped the
`themeprovider-storybook/register` addon, so stories were rendered
without a theme. Components that read theme-derived values (e.g.
`Alert` reading `theme.alert.background`) crashed because
`theme.alert` was undefined.

Adds `packages/plantswap-uikit/.storybook/preview.tsx` with a global
`ThemeProvider` decorator using the light theme, restoring the
behaviour that `themeprovider-storybook/register` provided before the
migration.

The Icons story also used webpack's `require.context` API to enumerate
icon components. Storybook v10 runs on Vite, where `require.context` is
not available. Replaces it with Vite's equivalent
`import.meta.glob('./Icons/*.tsx', { eager: true })` and resolves the
default export per module. The Icons folder has no subdirectories, so
the non-recursive glob matches the previous behaviour.