### PR TITLE
chore: Record gitHead after v1.0.1 publish

### DIFF
--- a/packages/eslint-config-plantswap/package.json
+++ b/packages/eslint-config-plantswap/package.json
@@ -29,5 +29,5 @@
   "publishConfig": {
     "access": "public"
   },
-  "gitHead": "7dfd3f87c835d6f3090934b184d614d045990577"
+  "gitHead": "49832ebd8f057c016a76be7bd72e5e7027276d36"
 }

--- a/packages/plantswap-uikit/package.json
+++ b/packages/plantswap-uikit/package.json
@@ -58,5 +58,5 @@
   "publishConfig": {
     "access": "public"
   },
-  "gitHead": "7dfd3f87c835d6f3090934b184d614d045990577"
+  "gitHead": "49832ebd8f057c016a76be7bd72e5e7027276d36"
 }


### PR DESCRIPTION
## Summary
- Update package `gitHead` fields to the `v1.0.1` release commit after the version bump publish

## Test plan
- [ ] Confirm `@plantswap/uikit@1.0.1` is on npm
- [ ] Confirm `@plantswap-libs/eslint-config-plantswap@1.0.1` is on npm (may still need publish)


Made with [Cursor](https://cursor.com)