### PR TITLE
feat: Add ErrorBoundary component to the uikit

### DIFF
--- a/packages/plantswap-uikit/README.md
+++ b/packages/plantswap-uikit/README.md
@@ -54,6 +54,48 @@ import { ResetCSS } from '@plantswap/uikit'
 <ResetCSS />
 ```
 
+### Error boundary
+
+`ErrorBoundary` catches render, lifecycle and constructor errors thrown by its descendants and
+swaps that subtree for a themed card instead of letting the whole app unmount. Wrap the app, a
+route, or any widget that can fail on its own.
+
+```jsx
+import { ErrorBoundary } from '@plantswap/uikit'
+;<ErrorBoundary onError={(error, errorInfo) => reportToSentry(error, errorInfo)}>
+  <FarmList />
+</ErrorBoundary>
+```
+
+The default card shows the error message and component stack outside of production builds only.
+Force it either way with `showDetails`, and adjust the copy with `title`, `description` and
+`actionText`.
+
+Pass `resetKeys` to recover automatically — the boundary clears its error whenever one of the
+values changes, which makes navigation a natural recovery point.
+
+```jsx
+<ErrorBoundary resetKeys={[pathname]}>
+  <Outlet />
+</ErrorBoundary>
+```
+
+For a completely different look, pass `fallback` — either a node, or a render function receiving
+the error and a reset handler.
+
+```jsx
+<ErrorBoundary
+  fallback={({ error, resetErrorBoundary }) => (
+    <MyCrashScreen message={error.message} onRetry={resetErrorBoundary} />
+  )}
+>
+  <FarmList />
+</ErrorBoundary>
+```
+
+Note that React error boundaries cannot catch errors thrown from event handlers, async callbacks,
+or server rendering. Store those in state and rethrow during render to surface them here.
+
 ### Types
 
 This project is built with Typescript and export all the relevant types.

--- a/packages/plantswap-uikit/src/__tests__/components/errorboundary.test.tsx
+++ b/packages/plantswap-uikit/src/__tests__/components/errorboundary.test.tsx
@@ -1,0 +1,358 @@
+import React, { useState } from "react";
+import { fireEvent, screen } from "@testing-library/react";
+import { renderWithTheme } from "../../testHelpers";
+import type { ErrorBoundaryFallbackProps } from "../../components/ErrorBoundary";
+import { ErrorBoundary } from "../../components/ErrorBoundary";
+
+const BOOM = "Failed to load the farm data";
+
+const Bomb: React.FC<{ shouldThrow: boolean }> = ({ shouldThrow }) => {
+  if (shouldThrow) {
+    throw new Error(BOOM);
+  }
+
+  return <div>Children rendered</div>;
+};
+
+/** Toggles the throwing child off through `onReset`, the way a consuming app would. */
+const ResettableHarness: React.FC<{ actionText?: string }> = ({ actionText }) => {
+  const [shouldThrow, setShouldThrow] = useState(true);
+
+  return (
+    <ErrorBoundary actionText={actionText} showDetails={false} onReset={() => setShouldThrow(false)}>
+      <Bomb shouldThrow={shouldThrow} />
+    </ErrorBoundary>
+  );
+};
+
+/** Recovers on "navigation" — the boundary resets itself when `resetKeys` changes. */
+const RouteHarness: React.FC = () => {
+  const [route, setRoute] = useState("farms");
+
+  return (
+    <div>
+      <button type="button" onClick={() => setRoute("pools")}>
+        Navigate
+      </button>
+      <ErrorBoundary resetKeys={[route]} fallback={<div>Fallback shown</div>}>
+        <Bomb shouldThrow={route === "farms"} />
+      </ErrorBoundary>
+    </div>
+  );
+};
+
+// React always logs caught boundary errors to the console; keep the suite output readable.
+let consoleError: jest.SpyInstance;
+
+beforeEach(() => {
+  consoleError = jest.spyOn(console, "error").mockImplementation(() => undefined);
+});
+
+afterEach(() => {
+  consoleError.mockRestore();
+});
+
+it("renders children when nothing throws", () => {
+  renderWithTheme(
+    <ErrorBoundary>
+      <Bomb shouldThrow={false} />
+    </ErrorBoundary>,
+  );
+
+  expect(screen.getByText("Children rendered")).toBeInTheDocument();
+});
+
+it("renders the default fallback when a child throws", () => {
+  const { asFragment } = renderWithTheme(
+    <ErrorBoundary showDetails={false}>
+      <Bomb shouldThrow />
+    </ErrorBoundary>,
+  );
+
+  expect(asFragment()).toMatchInlineSnapshot(`
+   <DocumentFragment>
+     .c10 {
+     align-items: center;
+     border: 0;
+     border-radius: 16px;
+     box-shadow: 0px -1px 0px 0px rgba(14, 14, 44, 0.4) inset;
+     cursor: pointer;
+     display: inline-flex;
+     font-family: inherit;
+     font-size: 16px;
+     font-weight: 600;
+     justify-content: center;
+     letter-spacing: 0.03em;
+     line-height: 1;
+     opacity: 1;
+     outline: 0;
+     transition: background-color 0.2s,opacity 0.2s;
+     height: 32px;
+     padding: 0 16px;
+     background-color: #2B6E37;
+     color: white;
+   }
+
+   .c10:hover:not(:disabled):not(.plant-button--disabled):not(.plant-button--disabled):not(:active) {
+     opacity: 0.65;
+   }
+
+   .c10:active:not(:disabled):not(.plant-button--disabled):not(.plant-button--disabled) {
+     opacity: 0.85;
+     transform: translateY(1px);
+     box-shadow: none;
+   }
+
+   .c10:disabled,
+   .c10.plant-button--disabled {
+     background-color: #E9EAEB;
+     border-color: #E9EAEB;
+     box-shadow: none;
+     color: #BDC2C4;
+     cursor: not-allowed;
+   }
+
+   .c6 {
+     align-self: center;
+     fill: #FFFFFF;
+     flex-shrink: 0;
+   }
+
+   .c11 {
+     align-self: center;
+     fill: currentColor;
+     flex-shrink: 0;
+     margin-right: 0.5rem;
+   }
+
+   .c0 {
+     background-color: #FFFFFF;
+     border: 0px 2px 12px -8px rgba(25, 19, 38, 0.1),0px 1px 1px rgba(25, 19, 38, 0.05);
+     border-radius: 24px;
+     box-shadow: 0px 2px 12px -8px rgba(25, 19, 38, 0.1),0px 1px 1px rgba(25, 19, 38, 0.05);
+     color: #4D2419;
+     overflow: hidden;
+     position: relative;
+   }
+
+   .c1 {
+     padding: 24px;
+   }
+
+   .c3 {
+     margin-bottom: 16px;
+   }
+
+   .c2 {
+     display: flex;
+     align-items: center;
+     flex-direction: column;
+   }
+
+   .c4 {
+     display: flex;
+   }
+
+   .c7 {
+     color: #4D2419;
+     font-size: 16px;
+     font-weight: 600;
+     line-height: 1.5;
+     margin-bottom: 8px;
+     text-align: center;
+   }
+
+   .c9 {
+     color: #2B6E37;
+     font-size: 16px;
+     font-weight: 400;
+     line-height: 1.5;
+     margin-bottom: 24px;
+     text-align: center;
+   }
+
+   .c8 {
+     font-size: 20px;
+     font-weight: 600;
+     line-height: 1.1;
+   }
+
+   .c5 {
+     align-items: center;
+     background-color: #AC2C2C;
+     border-radius: 50%;
+     height: 56px;
+     justify-content: center;
+     width: 56px;
+   }
+
+   @media screen and (min-width: 968px) {
+     .c8 {
+       font-size: 20px;
+     }
+   }
+
+   <div
+       class="c0"
+     >
+       <div
+         class="c1"
+       >
+         <div
+           class="c2"
+         >
+           <div
+             class="c3 c4 c5"
+           >
+             <svg
+               class="c6"
+               color="invertedContrast"
+               viewBox="0 0 24 24"
+               width="28px"
+               xmlns="http://www.w3.org/2000/svg"
+             >
+               <path
+                 d="M4.47 20.9999H19.53C21.07 20.9999 22.03 19.3299 21.26 17.9999L13.73 4.98993C12.96 3.65993 11.04 3.65993 10.27 4.98993L2.74 17.9999C1.97 19.3299 2.93 20.9999 4.47 20.9999ZM12 13.9999C11.45 13.9999 11 13.5499 11 12.9999V10.9999C11 10.4499 11.45 9.99993 12 9.99993C12.55 9.99993 13 10.4499 13 10.9999V12.9999C13 13.5499 12.55 13.9999 12 13.9999ZM13 17.9999H11V15.9999H13V17.9999Z"
+               />
+             </svg>
+           </div>
+           <h2
+             class="c7 c8"
+             color="text"
+             scale="md"
+           >
+             Something went wrong
+           </h2>
+           <div
+             class="c9"
+             color="textSubtle"
+           >
+             An unexpected error occurred and this section could not be displayed. Try again, or reload the page if the problem persists.
+           </div>
+           <button
+             class="c10"
+             scale="sm"
+           >
+             <svg
+               class="c11"
+               color="currentColor"
+               viewBox="0 0 24 24"
+               width="20px"
+               xmlns="http://www.w3.org/2000/svg"
+             >
+               <path
+                 d="M17.65 6.35C16.02 4.72 13.71 3.78 11.17 4.04C7.50002 4.41 4.48002 7.39 4.07002 11.06C3.52002 15.91 7.27002 20 12 20C15.19 20 17.93 18.13 19.21 15.44C19.53 14.77 19.05 14 18.31 14C17.94 14 17.59 14.2 17.43 14.53C16.3 16.96 13.59 18.5 10.63 17.84C8.41002 17.35 6.62002 15.54 6.15002 13.32C5.31002 9.44 8.26002 6 12 6C13.66 6 15.14 6.69 16.22 7.78L14.71 9.29C14.08 9.92 14.52 11 15.41 11H19C19.55 11 20 10.55 20 10V6.41C20 5.52 18.92 5.07 18.29 5.7L17.65 6.35Z"
+               />
+             </svg>
+             Try again
+           </button>
+         </div>
+       </div>
+     </div>
+   </DocumentFragment>
+  `);
+});
+
+it("shows the error details when showDetails is enabled", () => {
+  renderWithTheme(
+    <ErrorBoundary showDetails>
+      <Bomb shouldThrow />
+    </ErrorBoundary>,
+  );
+
+  expect(screen.getByText("Error details")).toBeInTheDocument();
+  expect(screen.getByText(new RegExp(BOOM))).toBeInTheDocument();
+});
+
+it("hides the error details when showDetails is disabled", () => {
+  renderWithTheme(
+    <ErrorBoundary showDetails={false}>
+      <Bomb shouldThrow />
+    </ErrorBoundary>,
+  );
+
+  expect(screen.queryByText("Error details")).not.toBeInTheDocument();
+});
+
+it("calls onError with the error and the component stack", () => {
+  const onError = jest.fn();
+
+  renderWithTheme(
+    <ErrorBoundary showDetails={false} onError={onError}>
+      <Bomb shouldThrow />
+    </ErrorBoundary>,
+  );
+
+  expect(onError).toHaveBeenCalledTimes(1);
+  const [error, errorInfo] = onError.mock.calls[0];
+  expect(error).toBeInstanceOf(Error);
+  expect(error.message).toBe(BOOM);
+  expect(typeof errorInfo.componentStack).toBe("string");
+});
+
+it("recovers when the default fallback action is pressed", () => {
+  renderWithTheme(<ResettableHarness />);
+
+  expect(screen.getByText("Something went wrong")).toBeInTheDocument();
+
+  fireEvent.click(screen.getByText("Try again"));
+
+  expect(screen.getByText("Children rendered")).toBeInTheDocument();
+});
+
+it("uses a custom action label", () => {
+  renderWithTheme(<ResettableHarness actionText="Reload the farm" />);
+
+  expect(screen.getByText("Reload the farm")).toBeInTheDocument();
+});
+
+it("renders a static fallback node when one is provided", () => {
+  renderWithTheme(
+    <ErrorBoundary fallback={<div>Static fallback</div>}>
+      <Bomb shouldThrow />
+    </ErrorBoundary>,
+  );
+
+  expect(screen.getByText("Static fallback")).toBeInTheDocument();
+  expect(screen.queryByText("Something went wrong")).not.toBeInTheDocument();
+});
+
+it("passes the error and a working reset handler to a fallback render function", () => {
+  const renderFallback = ({ error, resetErrorBoundary }: ErrorBoundaryFallbackProps) => (
+    <div>
+      <p>{error.message}</p>
+      <button type="button" onClick={resetErrorBoundary}>
+        Retry
+      </button>
+    </div>
+  );
+
+  const Harness: React.FC = () => {
+    const [shouldThrow, setShouldThrow] = useState(true);
+
+    return (
+      <ErrorBoundary onReset={() => setShouldThrow(false)} fallback={renderFallback}>
+        <Bomb shouldThrow={shouldThrow} />
+      </ErrorBoundary>
+    );
+  };
+
+  renderWithTheme(<Harness />);
+
+  expect(screen.getByText(BOOM)).toBeInTheDocument();
+
+  fireEvent.click(screen.getByText("Retry"));
+
+  expect(screen.getByText("Children rendered")).toBeInTheDocument();
+});
+
+it("resets itself when resetKeys change", () => {
+  renderWithTheme(<RouteHarness />);
+
+  expect(screen.getByText("Fallback shown")).toBeInTheDocument();
+
+  fireEvent.click(screen.getByText("Navigate"));
+
+  expect(screen.getByText("Children rendered")).toBeInTheDocument();
+  expect(screen.queryByText("Fallback shown")).not.toBeInTheDocument();
+});

--- a/packages/plantswap-uikit/src/components/ErrorBoundary/ErrorBoundary.tsx
+++ b/packages/plantswap-uikit/src/components/ErrorBoundary/ErrorBoundary.tsx
@@ -1,0 +1,80 @@
+import type { ErrorInfo, ReactNode } from "react";
+import React, { Component } from "react";
+import ErrorFallback from "./ErrorFallback";
+import type { ErrorBoundaryProps, ErrorBoundaryState } from "./types";
+
+const haveResetKeysChanged = (previous: unknown[] = [], next: unknown[] = []): boolean =>
+  previous.length !== next.length || next.some((key, index) => !Object.is(key, previous[index]));
+
+/**
+ * Catches render, lifecycle and constructor errors thrown by its descendants and swaps the
+ * subtree for a themed fallback instead of unmounting the whole app.
+ *
+ * React error boundaries cannot catch errors thrown in event handlers, in async callbacks,
+ * or during server rendering — rethrow those from state to surface them here.
+ */
+class ErrorBoundary extends Component<ErrorBoundaryProps, ErrorBoundaryState> {
+  public static getDerivedStateFromError(error: Error): ErrorBoundaryState {
+    // `componentDidCatch` fills in the component stack right after this.
+    return { error, errorInfo: null };
+  }
+
+  constructor(props: ErrorBoundaryProps) {
+    super(props);
+    this.state = { error: null, errorInfo: null };
+  }
+
+  public componentDidUpdate(prevProps: ErrorBoundaryProps): void {
+    const { resetKeys } = this.props;
+    const { error } = this.state;
+
+    if (error !== null && haveResetKeysChanged(prevProps.resetKeys, resetKeys)) {
+      this.resetErrorBoundary();
+    }
+  }
+
+  public componentDidCatch(error: Error, errorInfo: ErrorInfo): void {
+    const { onError } = this.props;
+
+    this.setState({ errorInfo });
+    onError?.(error, errorInfo);
+  }
+
+  private resetErrorBoundary = (): void => {
+    const { onReset } = this.props;
+
+    this.setState({ error: null, errorInfo: null });
+    onReset?.();
+  };
+
+  public render(): ReactNode {
+    const { children, fallback, title, description, actionText, showDetails } = this.props;
+    const { error, errorInfo } = this.state;
+
+    if (error === null) {
+      return children;
+    }
+
+    if (typeof fallback === "function") {
+      return fallback({ error, errorInfo, resetErrorBoundary: this.resetErrorBoundary });
+    }
+
+    if (fallback !== undefined) {
+      return fallback;
+    }
+
+    return (
+      <ErrorFallback
+        error={error}
+        errorInfo={errorInfo}
+        resetErrorBoundary={this.resetErrorBoundary}
+        title={title}
+        description={description}
+        actionText={actionText}
+        showDetails={showDetails}
+      />
+    );
+  }
+}
+
+export default ErrorBoundary;

--- a/packages/plantswap-uikit/src/components/ErrorBoundary/ErrorFallback.tsx
+++ b/packages/plantswap-uikit/src/components/ErrorBoundary/ErrorFallback.tsx
@@ -1,0 +1,103 @@
+import React from "react";
+import styled from "styled-components";
+import { Button } from "../Button";
+import { Card, CardBody } from "../Card";
+import { Flex } from "../Box";
+import { Heading } from "../Heading";
+import { Text } from "../Text";
+import { RefreshIcon, WarningIcon } from "../Svg";
+import isDevelopment from "../../util/isDevelopment";
+import type { ErrorFallbackProps } from "./types";
+
+const IconCircle = styled(Flex)`
+  align-items: center;
+  background-color: ${({ theme }) => theme.colors.failure};
+  border-radius: ${({ theme }) => theme.radii.circle};
+  height: 56px;
+  justify-content: center;
+  width: 56px;
+`;
+
+const Details = styled.details`
+  background-color: ${({ theme }) => theme.colors.background};
+  border: 1px solid ${({ theme }) => theme.colors.cardBorder};
+  border-radius: ${({ theme }) => theme.radii.default};
+  margin-top: 24px;
+  padding: 12px 16px;
+  text-align: left;
+  width: 100%;
+`;
+
+const Summary = styled.summary`
+  color: ${({ theme }) => theme.colors.textSubtle};
+  cursor: pointer;
+  font-size: 14px;
+  font-weight: 600;
+  list-style: none;
+
+  &::-webkit-details-marker {
+    display: none;
+  }
+`;
+
+const Stack = styled.pre`
+  color: ${({ theme }) => theme.colors.textSubtle};
+  font-size: 12px;
+  line-height: 1.4;
+  margin: 12px 0 0;
+  max-height: 240px;
+  overflow: auto;
+  white-space: pre-wrap;
+  word-break: break-word;
+`;
+
+const defaultDescription =
+  "An unexpected error occurred and this section could not be displayed. Try again, or reload the page if the problem persists.";
+
+/**
+ * The themed crash screen rendered by `ErrorBoundary` when no `fallback` is supplied.
+ * Exported so apps can reuse the same look from their own boundary or route handler.
+ */
+const ErrorFallback: React.FC<ErrorFallbackProps> = ({
+  error,
+  errorInfo,
+  resetErrorBoundary,
+  title = "Something went wrong",
+  description = defaultDescription,
+  actionText = "Try again",
+  showDetails,
+}) => {
+  const detailsVisible = showDetails ?? isDevelopment();
+
+  return (
+    <Card>
+      <CardBody>
+        <Flex alignItems="center" flexDirection="column">
+          <IconCircle mb="16px">
+            <WarningIcon color="invertedContrast" width="28px" />
+          </IconCircle>
+          <Heading scale="md" mb="8px" textAlign="center">
+            {title}
+          </Heading>
+          <Text color="textSubtle" mb="24px" textAlign="center">
+            {description}
+          </Text>
+          <Button scale="sm" onClick={resetErrorBoundary} startIcon={<RefreshIcon color="currentColor" width="20px" />}>
+            {actionText}
+          </Button>
+          {detailsVisible && (
+            <Details>
+              <Summary>Error details</Summary>
+              <Stack>
+                {error.message}
+                {errorInfo?.componentStack}
+              </Stack>
+            </Details>
+          )}
+        </Flex>
+      </CardBody>
+    </Card>
+  );
+};
+
+export default ErrorFallback;

--- a/packages/plantswap-uikit/src/components/ErrorBoundary/index.stories.tsx
+++ b/packages/plantswap-uikit/src/components/ErrorBoundary/index.stories.tsx
@@ -1,0 +1,101 @@
+import type { Meta } from "@storybook/react";
+import React, { useState } from "react";
+import styled from "styled-components";
+import { Button } from "../Button";
+import { Card, CardBody } from "../Card";
+import { Flex } from "../Box";
+import { Heading } from "../Heading";
+import { Text } from "../Text";
+import ErrorBoundary from "./ErrorBoundary";
+
+const Row = styled.div`
+  margin-bottom: 32px;
+`;
+
+export default {
+  title: "Components/ErrorBoundary",
+  component: ErrorBoundary,
+  argTypes: {},
+} as Meta;
+
+const Bomb: React.FC<{ shouldThrow: boolean }> = ({ shouldThrow }) => {
+  if (shouldThrow) {
+    throw new Error("Failed to load the farm data from the contract");
+  }
+
+  return <Text>Everything is growing just fine.</Text>;
+};
+
+export const Default: React.FC = () => {
+  const [shouldThrow, setShouldThrow] = useState(false);
+
+  return (
+    <div style={{ padding: "32px", width: "500px" }}>
+      <Row>
+        <Button scale="sm" mb="16px" onClick={() => setShouldThrow(true)}>
+          Crash the child
+        </Button>
+        <ErrorBoundary onReset={() => setShouldThrow(false)}>
+          <Bomb shouldThrow={shouldThrow} />
+        </ErrorBoundary>
+      </Row>
+    </div>
+  );
+};
+
+export const CustomCopy: React.FC = () => (
+  <div style={{ padding: "32px", width: "500px" }}>
+    <ErrorBoundary
+      title="This farm could not be loaded"
+      description="The pool data is temporarily unavailable. Your funds are safe."
+      actionText="Reload the farm"
+      showDetails={false}
+    >
+      <Bomb shouldThrow />
+    </ErrorBoundary>
+  </div>
+);
+
+export const CustomFallback: React.FC = () => (
+  <div style={{ padding: "32px", width: "500px" }}>
+    <ErrorBoundary
+      fallback={({ error, resetErrorBoundary }) => (
+        <Card>
+          <CardBody>
+            <Flex alignItems="center" flexDirection="column">
+              <Heading scale="md" mb="8px">
+                Custom fallback
+              </Heading>
+              <Text color="failure" mb="16px">
+                {error.message}
+              </Text>
+              <Button scale="sm" variant="secondary" onClick={resetErrorBoundary}>
+                Retry
+              </Button>
+            </Flex>
+          </CardBody>
+        </Card>
+      )}
+    >
+      <Bomb shouldThrow />
+    </ErrorBoundary>
+  </div>
+);
+
+export const WithResetKeys: React.FC = () => {
+  const [route, setRoute] = useState("farms");
+
+  return (
+    <div style={{ padding: "32px", width: "500px" }}>
+      <Text mb="16px">
+        The boundary below auto-recovers whenever <code>route</code> changes, the way it would on navigation.
+      </Text>
+      <Button scale="sm" mb="16px" onClick={() => setRoute(route === "farms" ? "pools" : "farms")}>
+        Navigate to {route === "farms" ? "pools" : "farms"}
+      </Button>
+      <ErrorBoundary resetKeys={[route]}>
+        <Bomb shouldThrow={route === "farms"} />
+      </ErrorBoundary>
+    </div>
+  );
+};

--- a/packages/plantswap-uikit/src/components/ErrorBoundary/index.tsx
+++ b/packages/plantswap-uikit/src/components/ErrorBoundary/index.tsx
@@ -1,0 +1,8 @@
+export { default as ErrorBoundary } from "./ErrorBoundary";
+export { default as ErrorFallback } from "./ErrorFallback";
+export type {
+  ErrorBoundaryProps,
+  ErrorBoundaryFallbackProps,
+  ErrorBoundaryFallbackRender,
+  ErrorFallbackProps,
+} from "./types";

--- a/packages/plantswap-uikit/src/components/ErrorBoundary/types.ts
+++ b/packages/plantswap-uikit/src/components/ErrorBoundary/types.ts
@@ -1,0 +1,52 @@
+import type { ErrorInfo, ReactNode } from "react";
+
+/** Presentation options shared by `ErrorBoundary` and its default `ErrorFallback`. */
+export interface ErrorFallbackOptions {
+  /** Title of the default fallback. */
+  title?: string;
+  /** Description of the default fallback. */
+  description?: string;
+  /** Label of the default fallback action button. */
+  actionText?: string;
+  /**
+   * Show the error message and component stack in the default fallback.
+   * Defaults to `true` outside of production builds.
+   */
+  showDetails?: boolean;
+}
+
+export interface ErrorBoundaryFallbackProps {
+  /** The error thrown by a descendant during render, in a lifecycle method, or in a constructor. */
+  error: Error;
+  /** React's error info, mainly `componentStack`. Null until `componentDidCatch` has run. */
+  errorInfo: ErrorInfo | null;
+  /** Clears the error state and re-renders the children. */
+  resetErrorBoundary: () => void;
+}
+
+export interface ErrorFallbackProps extends ErrorBoundaryFallbackProps, ErrorFallbackOptions {}
+
+export type ErrorBoundaryFallbackRender = (props: ErrorBoundaryFallbackProps) => ReactNode;
+
+export interface ErrorBoundaryProps extends ErrorFallbackOptions {
+  children?: ReactNode;
+  /**
+   * Either a static node, or a render function receiving the error and a reset handler.
+   * Defaults to the themed `ErrorFallback` card.
+   */
+  fallback?: ReactNode | ErrorBoundaryFallbackRender;
+  /** Called whenever an error is caught. Use it to report to Sentry, a logger, etc. */
+  onError?: (error: Error, errorInfo: ErrorInfo) => void;
+  /** Called after the boundary resets, either from the action button or from `resetKeys`. */
+  onReset?: () => void;
+  /**
+   * The boundary resets itself when any of these values change (shallow, index-wise compare).
+   * Handy to recover on navigation: `resetKeys={[pathname]}`.
+   */
+  resetKeys?: unknown[];
+}
+
+export interface ErrorBoundaryState {
+  error: Error | null;
+  errorInfo: ErrorInfo | null;
+}

--- a/packages/plantswap-uikit/src/index.ts
+++ b/packages/plantswap-uikit/src/index.ts
@@ -9,6 +9,7 @@ export * from "./components/Card";
 export * from "./components/Checkbox";
 export * from "./components/Dropdown";
 export * from "./components/EndPage";
+export * from "./components/ErrorBoundary";
 export * from "./components/FallingSprouts";
 export * from "./components/Heading";
 export * from "./components/Image";

--- a/packages/plantswap-uikit/src/util/isDevelopment.ts
+++ b/packages/plantswap-uikit/src/util/isDevelopment.ts
@@ -1,0 +1,25 @@
+// The uikit targets the browser and deliberately does not pull in `@types/node`, so
+// `process` is unknown to the compiler. Bundlers (webpack, vite, rollup) replace
+// `process.env.NODE_ENV` with a string literal at build time; the try/catch keeps the
+// read safe in the runtimes where they do not and `process` is genuinely undefined.
+declare const process: { env?: { NODE_ENV?: string } } | undefined;
+
+const getNodeEnv = (): string | undefined => {
+  try {
+    return process?.env?.NODE_ENV;
+  } catch {
+    return undefined;
+  }
+};
+
+/**
+ * True only when the bundle is known to be a non-production build. When `NODE_ENV` cannot
+ * be resolved we assume production, so debug output is never leaked by accident.
+ */
+const isDevelopment = (): boolean => {
+  const nodeEnv = getNodeEnv();
+
+  return nodeEnv !== undefined && nodeEnv !== "production";
+};
+
+export default isDevelopment;


### PR DESCRIPTION
## Why

Apps consuming `@plantswap/uikit` had no way to contain a React render crash. An uncaught error anywhere in the tree unmounted the whole app and the user was left staring at a blank white page. There was no `ErrorBoundary`, `componentDidCatch` or `getDerivedStateFromError` anywhere in the package.

The uikit is the right home for this: it already owns the theme, the `Card`/`Button`/`Text` primitives and the warning iconography, so the crash screen can look like the rest of the product instead of a bare "Something went wrong".

## What

`ErrorBoundary` catches render, lifecycle and constructor errors from its descendants and swaps that subtree for a themed fallback card.

```jsx
import { ErrorBoundary } from '@plantswap/uikit'

<ErrorBoundary onError={reportToSentry}>
  <FarmList />
</ErrorBoundary>
```

- **`fallback`** — a node, or a render function receiving `{ error, errorInfo, resetErrorBoundary }`
- **`onError` / `onReset`** — hooks for crash reporting and for clearing app state on recovery
- **`resetKeys`** — the boundary clears itself when any value changes, so navigation becomes a natural recovery point
- **`title` / `description` / `actionText`** — copy overrides on the default card
- **`showDetails`** — the error message and component stack are shown outside production builds only; this forces it either way

The default card is composed entirely from existing exports (`Card`, `CardBody`, `Flex`, `Heading`, `Text`, `Button`, `WarningIcon`, `RefreshIcon`) and reuses existing theme tokens, so **no new theme slot** was added and `theme/light.ts`, `theme/dark.ts` and `theme/index.ts` are untouched.

## Notes

- **No new dependency.** Hand-rolled rather than pulling in `react-error-boundary`, which keeps the `react ^17 || ^18 || ^19` peer range intact.
- Adds `src/util/isDevelopment.ts`. The package deliberately ships without `@types/node`, so `process` is untyped; the util declares it locally and reads `NODE_ENV` inside a try/catch, defaulting to "production" when it cannot be resolved so debug output is never leaked by accident.
- `ErrorBoundary` is the only class component in the package — React offers no hook equivalent. Error boundaries still cannot catch errors from event handlers, async callbacks or SSR; the README documents the rethrow-from-state workaround.

## Testing

10 new tests in `src/__tests__/components/errorboundary.test.tsx` covering pass-through rendering, the default fallback (inline snapshot, matching the package convention), details show/hide, `onError` payload, static and render-function fallbacks, action-button recovery and `resetKeys` recovery.

All five CI targets pass locally: `lint`, `format:check`, `test`, `build`, `storybook:build`.

Four stories under **Components/ErrorBoundary** in Storybook: `Default`, `CustomCopy`, `CustomFallback`, `WithResetKeys`.