### PR TITLE
feat(uikit): Add Error presentational component

### DIFF
--- a/packages/plantswap-uikit/src/__tests__/components/__snapshots__/error.test.tsx.snap
+++ b/packages/plantswap-uikit/src/__tests__/components/__snapshots__/error.test.tsx.snap
@@ -1,0 +1,88 @@
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
+
+exports[`renders correctly with a title 1`] = `
+<DocumentFragment>
+  .c0 {
+  display: flex;
+}
+
+.c4 {
+  color: #4D2419;
+  font-size: 16px;
+  font-weight: 600;
+  line-height: 1.5;
+  margin-bottom: 8px;
+}
+
+.c5 {
+  font-size: 20px;
+  font-weight: 600;
+  line-height: 1.1;
+}
+
+.c3 {
+  align-self: center;
+  fill: #AC2C2C;
+  flex-shrink: 0;
+}
+
+.c1 {
+  align-items: center;
+  background-color: #FFFFFF;
+  border: 1px solid #E7E3EB;
+  border-radius: 24px;
+  box-shadow: 0px 2px 12px -8px rgba(25, 19, 38, 0.1),0px 1px 1px rgba(25, 19, 38, 0.05);
+  flex-direction: column;
+  justify-content: center;
+  padding: 32px 24px;
+  text-align: center;
+}
+
+.c2 {
+  align-items: center;
+  background-color: #E9EAEB;
+  border-radius: 50%;
+  display: flex;
+  height: 72px;
+  justify-content: center;
+  margin-bottom: 16px;
+  width: 72px;
+}
+
+.c6 {
+  color: #4D2419;
+}
+
+@media screen and (min-width: 968px) {
+  .c5 {
+    font-size: 20px;
+  }
+}
+
+<div
+    class="c0 c1"
+  >
+    <div
+      class="c2"
+    >
+      <svg
+        class="c3"
+        color="failure"
+        viewBox="0 0 24 24"
+        width="40px"
+        xmlns="http://www.w3.org/2000/svg"
+      >
+        <path
+          d="M12 7C12.55 7 13 7.45 13 8V12C13 12.55 12.55 13 12 13C11.45 13 11 12.55 11 12V8C11 7.45 11.45 7 12 7ZM11.99 2C6.47 2 2 6.48 2 12C2 17.52 6.47 22 11.99 22C17.52 22 22 17.52 22 12C22 6.48 17.52 2 11.99 2ZM12 20C7.58 20 4 16.42 4 12C4 7.58 7.58 4 12 4C16.42 4 20 7.58 20 12C20 16.42 16.42 20 12 20ZM13 17H11V15H13V17Z"
+        />
+      </svg>
+    </div>
+    <h2
+      class="c4 c5 c6"
+      color="text"
+    >
+      Boom
+    </h2>
+  </div>
+</DocumentFragment>
+`;

--- a/packages/plantswap-uikit/src/__tests__/components/error.test.tsx
+++ b/packages/plantswap-uikit/src/__tests__/components/error.test.tsx
@@ -1,0 +1,21 @@
+import React from "react";
+import { renderWithTheme } from "../../testHelpers";
+import { Error } from "../../components/Error";
+
+it("renders correctly with a title", () => {
+  const { getByText, asFragment } = renderWithTheme(<Error title="Boom" />);
+  expect(getByText("Boom")).toBeInTheDocument();
+  expect(asFragment()).toMatchSnapshot();
+});
+
+it("renders code, description and custom children", () => {
+  const { getByText } = renderWithTheme(
+    <Error code={404} title="Not found" description="Page does not exist">
+      <span>extra content</span>
+    </Error>,
+  );
+  expect(getByText("404")).toBeInTheDocument();
+  expect(getByText("Not found")).toBeInTheDocument();
+  expect(getByText("Page does not exist")).toBeInTheDocument();
+  expect(getByText("extra content")).toBeInTheDocument();
+});

--- a/packages/plantswap-uikit/src/components/Error/Error.tsx
+++ b/packages/plantswap-uikit/src/components/Error/Error.tsx
@@ -1,0 +1,64 @@
+import React from "react";
+import styled from "styled-components";
+import { space } from "styled-system";
+import { Box, Flex } from "../Box";
+import { Heading } from "../Heading";
+import { Text } from "../Text";
+import { ErrorIcon } from "../Svg";
+import type { ErrorProps } from "./types";
+
+const Container = styled(Flex)`
+  align-items: center;
+  background-color: ${({ theme }) => theme.error.background};
+  border: 1px solid ${({ theme }) => theme.error.borderColor};
+  border-radius: ${({ theme }) => theme.radii.card};
+  box-shadow: ${({ theme }) => theme.shadows.level1};
+  flex-direction: column;
+  justify-content: center;
+  padding: 32px 24px;
+  text-align: center;
+
+  ${space}
+`;
+
+const IconWrapper = styled(Box)`
+  align-items: center;
+  background-color: ${({ theme }) => theme.colors.backgroundDisabled};
+  border-radius: ${({ theme }) => theme.radii.circle};
+  display: flex;
+  height: 72px;
+  justify-content: center;
+  margin-bottom: 16px;
+  width: 72px;
+`;
+
+const Code = styled(Text)`
+  letter-spacing: 1px;
+  margin-bottom: 8px;
+  text-transform: uppercase;
+`;
+
+const Title = styled(Heading)`
+  color: ${({ theme }) => theme.error.titleColor};
+`;
+
+const Description = styled(Text)`
+  color: ${({ theme }) => theme.error.descriptionColor};
+  margin-bottom: 16px;
+  max-width: 480px;
+`;
+
+const Error: React.FC<ErrorProps> = ({ code, title, description, action, icon, children, ...props }) => (
+  <Container {...props}>
+    <IconWrapper>{icon ?? <ErrorIcon width="40px" color="failure" />}</IconWrapper>
+    {code !== undefined && <Code bold>{code}</Code>}
+    <Title as="h2" mb="8px">
+      {title}
+    </Title>
+    {description && <Description>{description}</Description>}
+    {action && <Box>{action}</Box>}
+    {children}
+  </Container>
+);
+
+export default Error;

--- a/packages/plantswap-uikit/src/components/Error/index.stories.tsx
+++ b/packages/plantswap-uikit/src/components/Error/index.stories.tsx
@@ -1,0 +1,35 @@
+import React from "react";
+import { Button } from "../Button";
+import Error from "./Error";
+
+export default {
+  title: "Components/Error",
+  component: Error,
+  argTypes: {},
+};
+
+export const Default: React.FC = () => <Error title="Something went wrong" />;
+
+export const WithDescription: React.FC = () => (
+  <Error
+    title="Something went wrong"
+    description="We couldn't load the latest data. Check your connection and try again."
+  />
+);
+
+export const WithCodeAndAction: React.FC = () => (
+  <Error
+    code={500}
+    title="Internal Server Error"
+    description="The server encountered an unexpected condition that prevented it from fulfilling the request."
+    action={<Button onClick={() => window.location.reload()}>Try again</Button>}
+  />
+);
+
+export const CustomIcon: React.FC = () => (
+  <Error
+    icon={<span style={{ fontSize: 32 }}>🌱</span>}
+    title="No sprouts yet"
+    description="Start planting to grow your first sprout."
+  />
+);

--- a/packages/plantswap-uikit/src/components/Error/index.tsx
+++ b/packages/plantswap-uikit/src/components/Error/index.tsx
@@ -1,0 +1,2 @@
+export { default as Error } from "./Error";
+export type { ErrorProps, ErrorTheme } from "./types";

--- a/packages/plantswap-uikit/src/components/Error/theme.ts
+++ b/packages/plantswap-uikit/src/components/Error/theme.ts
@@ -1,0 +1,18 @@
+import { darkColors, lightColors } from "../../theme/colors";
+import type { ErrorTheme } from "./types";
+
+export const light: ErrorTheme = {
+  background: "#FFFFFF",
+  titleColor: lightColors.text,
+  descriptionColor: lightColors.textSubtle,
+  iconColor: lightColors.failure,
+  borderColor: lightColors.cardBorder,
+};
+
+export const dark: ErrorTheme = {
+  background: darkColors.backgroundAlt,
+  titleColor: darkColors.text,
+  descriptionColor: darkColors.textSubtle,
+  iconColor: darkColors.failure,
+  borderColor: darkColors.cardBorder,
+};

--- a/packages/plantswap-uikit/src/components/Error/types.ts
+++ b/packages/plantswap-uikit/src/components/Error/types.ts
@@ -1,0 +1,37 @@
+import type { ReactNode } from "react";
+import type { SpaceProps } from "styled-system";
+
+export type ErrorTheme = {
+  background: string;
+  titleColor: string;
+  descriptionColor: string;
+  iconColor: string;
+  borderColor: string;
+};
+
+export interface ErrorProps extends SpaceProps {
+  /**
+   * Optional error code shown above the title (e.g. HTTP status, contract error code).
+   */
+  code?: string | number;
+  /**
+   * Short, human-readable title for the error.
+   */
+  title: string;
+  /**
+   * Longer description explaining what went wrong and/or how to recover.
+   */
+  description?: ReactNode;
+  /**
+   * Optional call-to-action rendered below the description (typically a `Button`).
+   */
+  action?: ReactNode;
+  /**
+   * Optional icon override. Defaults to the inline `ErrorIcon`.
+   */
+  icon?: ReactNode;
+  /**
+   * Optional full override for the body content.
+   */
+  children?: ReactNode;
+}

--- a/packages/plantswap-uikit/src/index.ts
+++ b/packages/plantswap-uikit/src/index.ts
@@ -9,6 +9,7 @@ export * from "./components/Card";
 export * from "./components/Checkbox";
 export * from "./components/Dropdown";
 export * from "./components/EndPage";
+export * from "./components/Error";
 export * from "./components/ErrorBoundary";
 export * from "./components/FallingSprouts";
 export * from "./components/Heading";

--- a/packages/plantswap-uikit/src/theme/dark.ts
+++ b/packages/plantswap-uikit/src/theme/dark.ts
@@ -1,6 +1,7 @@
 import type { DefaultTheme } from "styled-components";
 import { dark as darkAlert } from "../components/Alert/theme";
 import { dark as darkCard } from "../components/Card/theme";
+import { dark as darkError } from "../components/Error/theme";
 import { dark as darkPlantToggle } from "../components/PlantToggle/theme";
 import { dark as darkRadio } from "../components/Radio/theme";
 import { dark as darkToggle } from "../components/Toggle/theme";
@@ -16,6 +17,7 @@ const darkTheme: DefaultTheme = {
   alert: darkAlert,
   colors: darkColors,
   card: darkCard,
+  error: darkError,
   toggle: darkToggle,
   nav: darkNav,
   modal: darkModal,

--- a/packages/plantswap-uikit/src/theme/index.ts
+++ b/packages/plantswap-uikit/src/theme/index.ts
@@ -1,5 +1,6 @@
 import type { AlertTheme } from "../components/Alert/types";
 import type { CardTheme } from "../components/Card/types";
+import type { ErrorTheme } from "../components/Error/types";
 import type { PlantToggleTheme } from "../components/PlantToggle/types";
 import type { RadioTheme } from "../components/Radio/types";
 import type { ToggleTheme } from "../components/Toggle/types";
@@ -14,6 +15,7 @@ export interface PlantTheme {
   alert: AlertTheme;
   colors: Colors;
   card: CardTheme;
+  error: ErrorTheme;
   nav: NavTheme;
   modal: ModalTheme;
   plantToggle: PlantToggleTheme;

--- a/packages/plantswap-uikit/src/theme/light.ts
+++ b/packages/plantswap-uikit/src/theme/light.ts
@@ -1,6 +1,7 @@
 import type { DefaultTheme } from "styled-components";
 import { light as lightAlert } from "../components/Alert/theme";
 import { light as lightCard } from "../components/Card/theme";
+import { light as lightError } from "../components/Error/theme";
 import { light as lightPlantToggle } from "../components/PlantToggle/theme";
 import { light as lightRadio } from "../components/Radio/theme";
 import { light as lightToggle } from "../components/Toggle/theme";
@@ -16,6 +17,7 @@ const lightTheme: DefaultTheme = {
   alert: lightAlert,
   colors: lightColors,
   card: lightCard,
+  error: lightError,
   toggle: lightToggle,
   nav: lightNav,
   modal: lightModal,


### PR DESCRIPTION
## Summary
- Add a reusable `Error` UI component for empty/error states (code, title, description, action, icon)
- Wire light/dark theme tokens into the Plant theme
- Export from the uikit package with Storybook stories and snapshot coverage

## Test plan
- [ ] Confirm Storybook `Components/Error` stories render in light and dark themes
- [ ] Run uikit unit tests and verify `error.test.tsx` + snapshot pass
- [ ] Confirm package exports include both `Error` and existing `ErrorBoundary`


Made with [Cursor](https://cursor.com)